### PR TITLE
fix: remove redundant path specification in Quarto publish workflow

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -98,7 +98,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-site
-          path: _site
 
       - name: Start static server
         run: |
@@ -121,7 +120,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-site
-          path: _site
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -98,6 +98,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-site
+          path: _site
 
       - name: Start static server
         run: |
@@ -120,6 +121,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-site
+          path: _site
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -130,7 +132,6 @@ jobs:
         uses: quarto-dev/quarto-actions/publish@v2
         with:
           target: gh-pages
-          path: _site
           render: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions


### PR DESCRIPTION
# Pull request

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Release Notes:  
This update includes behind-the-scenes optimizations to our deployment processes. While there are no visible changes to the end-user experience, these improvements help maintain smooth and efficient operations across our platform.

- **Chores**
  - Streamlined internal deployment workflows by removing the specification of the publishing path.
  - Optimized configuration setups to ensure robust and efficient operational performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->